### PR TITLE
Update supervisely packages to 6.74.24 and bump image to 1.0.35

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,8 +1,8 @@
 # git+https://github.com/supervisely/supervisely.git@test-sdk-branch
 
-supervisely[training]==6.74.18
-supervisely[tracking]==6.74.18
-supervisely[model-benchmark]==6.74.18
+supervisely[training]==6.74.24
+supervisely[tracking]==6.74.24
+supervisely[model-benchmark]==6.74.24
 
 torch==2.7.1
 torchvision==0.22.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,8 +51,8 @@ RUN pip install --no-cache-dir ultralytics==8.4.6
 RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0
 RUN pip install --no-cache-dir transformers==4.50.3 calflops==0.3.2 scipy==1.15.2 faster-coco-eval==1.6.5
 
-RUN pip install --no-cache-dir supervisely[training]==6.74.18
-RUN pip install --no-cache-dir supervisely[tracking]==6.74.18
-RUN pip install --no-cache-dir supervisely[model-benchmark]==6.74.18
+RUN pip install --no-cache-dir supervisely[training]==6.74.24
+RUN pip install --no-cache-dir supervisely[tracking]==6.74.24
+RUN pip install --no-cache-dir supervisely[model-benchmark]==6.74.24
 
-LABEL python_sdk_version="6.74.18"
+LABEL python_sdk_version="6.74.24"

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -1,2 +1,2 @@
-docker build -t supervisely/yolo:1.0.34 . && \
-docker push supervisely/yolo:1.0.34
+docker build -t supervisely/yolo:1.0.35 . && \
+docker push supervisely/yolo:1.0.35

--- a/supervisely_integration/serve/config.json
+++ b/supervisely_integration/serve/config.json
@@ -17,7 +17,7 @@
         "framework:YOLO"
     ],
     "task_location": "application_sessions",
-    "docker_image": "supervisely/yolo:1.0.34",
+    "docker_image": "supervisely/yolo:1.0.35",
     "cuda_version": 12.8,
     "community_agent": false,
     "need_gpu": false,

--- a/supervisely_integration/train/config.json
+++ b/supervisely_integration/train/config.json
@@ -17,7 +17,7 @@
         "framework:YOLO"
     ],
     "task_location": "workspace_tasks",
-    "docker_image": "supervisely/yolo:1.0.34",
+    "docker_image": "supervisely/yolo:1.0.35",
     "cuda_version": 12.8,
     "community_agent": false,
     "need_gpu": true,


### PR DESCRIPTION
SDK 6.74.24 fixes a KeyError raised by TrainValSplits.get_splits() ("Based on datasets" split) whenever a selected dataset was nested under a parent dataset.