### PR TITLE
Update supervisely packages to 6.74.25 and bump image to 1.0.36

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,8 +1,8 @@
 # git+https://github.com/supervisely/supervisely.git@test-sdk-branch
 
-supervisely[training]==6.74.24
-supervisely[tracking]==6.74.24
-supervisely[model-benchmark]==6.74.24
+supervisely[training]==6.74.25
+supervisely[tracking]==6.74.25
+supervisely[model-benchmark]==6.74.25
 
 torch==2.7.1
 torchvision==0.22.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,8 +51,8 @@ RUN pip install --no-cache-dir ultralytics==8.4.6
 RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0
 RUN pip install --no-cache-dir transformers==4.50.3 calflops==0.3.2 scipy==1.15.2 faster-coco-eval==1.6.5
 
-RUN pip install --no-cache-dir supervisely[training]==6.74.24
-RUN pip install --no-cache-dir supervisely[tracking]==6.74.24
-RUN pip install --no-cache-dir supervisely[model-benchmark]==6.74.24
+RUN pip install --no-cache-dir supervisely[training]==6.74.25
+RUN pip install --no-cache-dir supervisely[tracking]==6.74.25
+RUN pip install --no-cache-dir supervisely[model-benchmark]==6.74.25
 
-LABEL python_sdk_version="6.74.24"
+LABEL python_sdk_version="6.74.25"

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -1,2 +1,2 @@
-docker build -t supervisely/yolo:1.0.35 . && \
-docker push supervisely/yolo:1.0.35
+docker build -t supervisely/yolo:1.0.36 . && \
+docker push supervisely/yolo:1.0.36

--- a/supervisely_integration/serve/config.json
+++ b/supervisely_integration/serve/config.json
@@ -17,7 +17,7 @@
         "framework:YOLO"
     ],
     "task_location": "application_sessions",
-    "docker_image": "supervisely/yolo:1.0.35",
+    "docker_image": "supervisely/yolo:1.0.36",
     "cuda_version": 12.8,
     "community_agent": false,
     "need_gpu": false,

--- a/supervisely_integration/train/config.json
+++ b/supervisely_integration/train/config.json
@@ -17,7 +17,7 @@
         "framework:YOLO"
     ],
     "task_location": "workspace_tasks",
-    "docker_image": "supervisely/yolo:1.0.35",
+    "docker_image": "supervisely/yolo:1.0.36",
     "cuda_version": 12.8,
     "community_agent": false,
     "need_gpu": true,


### PR DESCRIPTION
Picks up the SDK fix for the "Based on collections" train/val split crashing with AttributeError: 'NoneType' object has no attribute 'get_item_paths' when a dataset referenced by a collection was renamed/moved after the project was downloaded for training.

See supervisely/supervisely#(fix/collections-split-stale-dataset).