### PR TITLE
Update supervisely packages to 6.74.26 and bump image to 1.0.37

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,8 +1,8 @@
 # git+https://github.com/supervisely/supervisely.git@test-sdk-branch
 
-supervisely[training]==6.74.25
-supervisely[tracking]==6.74.25
-supervisely[model-benchmark]==6.74.25
+supervisely[training]==6.74.26
+supervisely[tracking]==6.74.26
+supervisely[model-benchmark]==6.74.26
 
 torch==2.7.1
 torchvision==0.22.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,8 +51,8 @@ RUN pip install --no-cache-dir ultralytics==8.4.6
 RUN pip install --no-cache-dir setuptools==69.5.1 tensorboard imgaug==0.4.0
 RUN pip install --no-cache-dir transformers==4.50.3 calflops==0.3.2 scipy==1.15.2 faster-coco-eval==1.6.5
 
-RUN pip install --no-cache-dir supervisely[training]==6.74.25
-RUN pip install --no-cache-dir supervisely[tracking]==6.74.25
-RUN pip install --no-cache-dir supervisely[model-benchmark]==6.74.25
+RUN pip install --no-cache-dir supervisely[training]==6.74.26
+RUN pip install --no-cache-dir supervisely[tracking]==6.74.26
+RUN pip install --no-cache-dir supervisely[model-benchmark]==6.74.26
 
-LABEL python_sdk_version="6.74.25"
+LABEL python_sdk_version="6.74.26"

--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -1,2 +1,2 @@
-docker build -t supervisely/yolo:1.0.36 . && \
-docker push supervisely/yolo:1.0.36
+docker build -t supervisely/yolo:1.0.37 . && \
+docker push supervisely/yolo:1.0.37

--- a/supervisely_integration/serve/config.json
+++ b/supervisely_integration/serve/config.json
@@ -17,7 +17,7 @@
         "framework:YOLO"
     ],
     "task_location": "application_sessions",
-    "docker_image": "supervisely/yolo:1.0.36",
+    "docker_image": "supervisely/yolo:1.0.37",
     "cuda_version": 12.8,
     "community_agent": false,
     "need_gpu": false,

--- a/supervisely_integration/train/config.json
+++ b/supervisely_integration/train/config.json
@@ -17,7 +17,7 @@
         "framework:YOLO"
     ],
     "task_location": "workspace_tasks",
-    "docker_image": "supervisely/yolo:1.0.36",
+    "docker_image": "supervisely/yolo:1.0.37",
     "cuda_version": 12.8,
     "community_agent": false,
     "need_gpu": true,


### PR DESCRIPTION
Picks up the SDK fix that skips unresolvable items in a "Based on collections" train/val split instead of hard-failing the whole run when a dataset referenced by a collection was deleted (or moved out of the project) after the collection was created.

See supervisely/supervisely@96a647ed.